### PR TITLE
References to parent objects should be weakened

### DIFF
--- a/lib/DBIx/Class/Schema/Diff/InfoPacket.pm
+++ b/lib/DBIx/Class/Schema/Diff/InfoPacket.pm
@@ -13,7 +13,7 @@ has 'new_info', required => 1, is => 'ro', isa => Maybe[HashRef];
 
 has 'diff_added', is => 'ro', isa => Bool, default => sub { 0 };
 
-has '_source_diff', required => 1, is => 'ro', isa => InstanceOf[
+has '_source_diff', required => 1, is => 'ro', weak_ref => 1, isa => InstanceOf[
   'DBIx::Class::Schema::Diff::Source'
 ];
 

--- a/lib/DBIx/Class/Schema/Diff/Source.pm
+++ b/lib/DBIx/Class/Schema/Diff/Source.pm
@@ -17,7 +17,7 @@ has 'new_source', required => 1, is => 'ro', isa => Maybe[HashRef];
 
 has 'diff_added', is => 'ro', isa => Bool, default => sub { 0 };
 
-has '_schema_diff', required => 1, is => 'ro', isa => InstanceOf[
+has '_schema_diff', required => 1, is => 'ro', weak_ref => 1, isa => InstanceOf[
   'DBIx::Class::Schema::Diff::Schema'
 ];
 


### PR DESCRIPTION
The tree of objects from Schema to Source and from Source to InfoPacket
have back references from the child to the parent.  If not weakened,
these create a circular reference and memory leak.  It is unlikely that
the diffs would be produced very many times in a long-running program,
but better to plug the leak regardless.